### PR TITLE
Added path_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,3 +394,7 @@ If you're using Moonrope in a Rails application it will automatically be added
 to your Rack middleware stack. If not, you'll need to add it manually.
 
 By default, the API is exposed at `/api/v1/controller/action`.
+
+### Path Prefix
+
+The Path Prefix by default is set as `api`. This can be changed by setting the `Moonrope::Request.path_prefix` option.

--- a/lib/moonrope/request.rb
+++ b/lib/moonrope/request.rb
@@ -2,11 +2,16 @@ module Moonrope
   class Request
 
     class << self
-      attr_accessor :path_regex
+      attr_accessor :path_regex, :path_prefix
+
+      # @return [String] the prefix for API requests
+      def path_prefix
+        @path_prefix ||= "api"
+      end
 
       # @return [Regex] the regex which should be matched for all API requests
       def path_regex
-        @path_regex ||= /\A\/api\/([\w\/\-\.]+)?/
+        @path_regex ||= /\A\/#{self.path_prefix}\/([\w\/\-\.]+)?/
       end
     end
 


### PR DESCRIPTION
I've added a `path_prefix` method if you don't want to use the `/api/` prefix.
I've tested this in an app I'm working on where I want to keep the old API running for the moment and it's working well so far.